### PR TITLE
Modifica  D-Refs

### DIFF
--- a/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
+++ b/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
@@ -37,6 +37,10 @@
 1. Sustainability in Italian Ceramic Tile Production: Evaluation of the Environmental Impact (OD)
 #### Rivestimenti resilienti e laminati
 1. Guida tecnica per pavimenti e rivestimenti LAMINAM
+#### Isolanti acustici
+1. Guida all'siolamento acustico e capitolati tecnici INDEX
+1. Rapporto di prova dell'siolamento acustico via aerea ISTITUTO GIORDANO (OD)
+1. Sistema per l'isolamento acustico contro il rumore di calpestio MAPEI
 
 ### Riferimenti normativi
 #### Pavimentazioni in resina
@@ -78,3 +82,8 @@ piastrellature ceramiche
 1. UNI EN ISO 11855-5 Progettazione dell'ambiente costruito - Progettazione, dimensionamento,
 installazione e controllo dei sistemi di riscaldamento e raffreddamento radianti integrati - Parte 5: Installazione.
 1. UNI EN 1264-4 Istallazione – Parte 4: Sistemi radianti alimentati ad acqua per il riscaldamento e il raffrescamento integrati nelle strutture.
+#### Isolanti acustici
+1. Legge 26 ottobre 1995, n. 447 Legge quadro sull'inquinamento acustico
+1. D.P.C.M. 5 dicembre 1997 - Determinazione dei requisiti acustici passivi degli edifici Pubblicato in G.U. Serie generale n. 297 del 22 dicembre 1997 (OD di ANIT)
+1. UNI EN 12354-2:2002 Acustica in edilizia - Valutazioni delle prestazioni acustiche di edifici a partire dalle prestazioni di prodotti - Isolamento acustico al calpestio tra ambienti
+1. UNI EN ISO 717-1:2021 Acustica - Valutazione dell'isolamento acustico in edifici e di elementi di edificio - Parte 1: Isolamento acustico per via aerea

--- a/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
+++ b/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
@@ -1,34 +1,80 @@
 # D-Pavimentazioni e rivestimenti di pavimentazione
 ## Riferimenti
 
- 1. Codice di pratica per la posa in opera di masselli autobloccanti in calcestruzzo
- 1. Linee Guida per la determinazione della capacità drenante delle pavimentazioni modulari in calcestruzzo
- 1. Codice di pratica per la manutenzione di masselli autobloccanti in calcestruzzo
- 1. SOTTOFONDI - Catalogo per il dimensionamento di pavimentazioni in masselli autobloccanti in calcestruzzo in ambito urbano
- 1. Linea guida “Impiego delle sostanze riciclate, recuperate e/o sottoprodotti” Gruppo Blocchi e Pavimenti
- 1. Pavimenti industriali in calcestruzzo
+### Documenti produttori e associazioni di produttori
+1. Codice di buona pratica CONPAVIPER (OD)
+#### pavimentazioni in calcestruzzo
+1. Codice di pratica CECCOONI 2222  per la posa in opera di masselli autobloccanti in calcestruzzo  (OD)
+1. Codice di pratica COLOMBO 2222  per la manutenzione di masselli autobloccanti in calcestruzzo (OD)
+1. Catalogo COLOMBO 2222  per il dimensionamento di pavimentazioni in masselli autobloccanti in calcestruzzo in ambito urbano (OD)
+1. Linee Guida PILOTTI 2011  per la determinazione della capacità drenante delle pavimentazioni modulari in calcestruzzo (OD)
+1. Linee Guida CONPAVIPER per la prescrizione di calcestruzzi fibrorinforzati per la realizzazione di pavimentazioni (OD)
+1. Voci di capitolato HARDCRETE (fac-simile) per pavimentazione industriale in calcestruzzo su massicciata (OD)
+1. Voci di capitolato HARDCRETE (fac-simile) per pavimento industriale su solaio (OD)
+1. Unicalcestruzzi - Guida alla scelta dei calcestruzzi per pavimenti industriali (OD)
+1. Istruzioni CNR per pavimenti industriali in calcestruzzo (OD)
+1. Federbeton – Pavimentazioni stradali in calcestruzzo. Approfondimenti (OD)
+1. Facoltà di Ingegneria dell’Università di Trento. Appunti di progettazione – Giunti e ritiri (OD)
+1.  1. Linea guida “Impiego delle sostanze riciclate, recuperate e/o sottoprodotti” Gruppo Blocchi e Pavimenti (NT : assobeton, privato https://www.assobeton.it/ASSOBETON/gest_sito.nsf/Document_List.xsp?documentId=D44A77FFB3431928C12583F9003CA1A8&action=openDocument&ord=data)
+1. Codice di buona pratica massetti e pavimentazioni industriali CONPAVIPER (OD)
+1. Voci di capitolato per pavimento carrabile in calcestruzzo stampato IDEAL WORK (OD).
+1. Pavimento in calcestruzzo architettonico Chromofibre PIERI (OD)
+#### Pavimentazioni in resina
+1. Linee Guida CONPAVIPER per la prescrizione, posa, controlli, verifica finale e manutenzione dei rivestimenti resinosi continui (OD)
+1. Pavimenti in resina codice di buona pratica CONPAVIPER (OD)
+1. BASF CC – Ucrete – PoliuretanoCemento (OD)
+#### Revistimenti lapidei
+1. Istruzioni per la progettazione la posa e la manutenzionedei rivestimenti lapidei per le pavimentazioni UNI
+1. La posa dei materiali lapidei MAPEI- Materiali e sistemi per la posa corretta di materiali lapidei naturali e ricomposti (OD)
+1. La posa sicura del rivestimento ceramico e lapideo TORGGLER (OD)
+#### Parquet e pavimentazioni in legno
+1. Posa e manutenzione di ORIGINAL PARQUET (https://originalparquet.com/posa-e-manutenzione/)
+1. Posa FEDERLEGNO (OD)
+1. Posa parquet SEMAU
+#### Piastrellature ceramiche
+1. Guida alla valutazione tecnica delle pistraellature in ceramica (OD)
+1. ITA_Ceramica_amica_2021 di CONFINDUSTRIA CERAMICA(OD)
+1. Sustainability in Italian Ceramic Tile Production: Evaluation of the Environmental Impact (OD)
+#### Rivestimenti resilienti e laminati
+1. Guida tecnica per pavimenti e rivestimenti LAMINAM
 
-https://www.pavimentiindustriali.com/download
-
- 1. Linee Guida CONPAVIPER per la prescrizione di calcestruzzi fibrorinforzati per la realizzazione di pavimentazioni
- 1. Codice di buona pratica CONPAVIPER
- 1. Voci di capitolato (fac-simile) per pavimentazione industriale in calcestruzzo su massicciata.
- 1. Voci di capitolato (fac-simile) per pavimento industriale su solaio.
- 1. Unicalcestruzzi - Guida alla scelta dei calcestruzzi per pavimenti industriali.
- 1. Federbeton – Pavimentazioni stradali in calcestruzzo. Approfondimenti.
- 1. Facoltà di Ingegneria dell’Università di Trento. Appunti di progettazione – Giunti e ritiri.
- 1. Istruzioni CNR per pavimenti industriali in calcestruzzo
-
-
- 1. Linee Guida CONPAVIPER per la prescrizione, posa, controlli, verifica finale e manutenzione dei rivestimenti resinosi continui
- 1. Pavimenti in resina per parcheggi MAPEI
- 1. Codice di buona pratica pavimenti in resina – edito da CONPAVIPER
- 1. Sistemi applicativi
- 1. BASF CC – Ucrete – PoliuretanoCemento.
- 1. Codice di buona pratica massetti
- 1. Voci di capitolato per pavimento carrabile in calcestruzzo stampato.
- 1. Pavimento in calcestruzzo architettonico Chromofibre
- 1. Linee Guida Valutazione delle caratteristiche del CLS in opera
-
-
- 1.  UNI 11714:2018, Rivestimenti lapidei di superfici orizzontali, verticali e soffitti - Parte 1: Istruzioni per la progettazione, la posa e la manutenzione
+### Riferimenti normativi
+#### Pavimentazioni in resina
+1. UNI 10966 Sistemi resinosi per superfici orizzontali, verticali e soffitti - Parte 1 : Istruzioni per la progettazione, la posa e la manutenzione
+1. UNI 8298-1 Rivestimenti resinosi per pavimentazioni - Determinazione dell'adesione del rivestimento al supporto.
+#### Rivestimenti resilienti e laminati
+1. UNI 11515-1 Rivestimenti resilienti e laminati per pavimentazioni. Parte 1_Istruzioni per la progettazione, la posa e la manutenzione.
+#### Revistimenti lapidei
+1.  UNI 11714:2018, Rivestimenti lapidei di superfici orizzontali, verticali e soffitti - Parte 1: Istruzioni per la progettazione, la posa e la manutenzione
+#### Parquet e pavimentazioni in legno
+1. UNI EN 14342 avimentazioni di legno e parquet - Caratteristiche, valutazione di conformità e marcatura.
+1. UNI 11371 Massetti per parquet e pavimentazioni in legno . proprietà e caratteristiche prestazionali
+1. UNI 11368-1 Pavimentazioni in legno. Posa in opera – Criteri e metodi di valutazione. Parte 1: Posa mediante incollaggio.
+1. UNI 11622 Pavimentazioni di legno e/o a base di legno per interni - Trattamenti di protezione superficiale - Parte 1: Requisiti minimi dei cicli di verniciatura
+1. UNI 11368-2 Pavimentazioni in legno. Posa in opera – Criteri e metodi di valutazione. Parte 2: Posa flottante.
+#### Piastrellature ceramiche
+1. UNI 11493 Piastrellature ceramiche a pavimento e a parete. Parte 1-Istruzioni per la progettazione, l'installazione e la manutenzione.
+#### Pavimentazoni galleggianti
+1. UNI 11516 Indicazioni di posa in opera dei sistemi di pavimentazione galleggiante per l'isolamento acustico.
+1. CEN/TR 13548 - Regole generali per la progettazione e l’installazione delle
+piastrellature ceramiche
+1. Pdf riassuntivo delle UNI 11516 e CEN/TR 13548 (OD)
+#### Schermi e mebrane
+1. UNI 11470 Coperture discontinue. Schermi e membrane traspiranti sintetiche. Definizione, campo di applicazione e posa in opera
+#### Pavimenti anti-scivolo
+1. DM 236/89, contiene la definizione secondo la BCRA
+1. UNI EN 13036-4 Caratteristiche superficiali delle pavimentazioni stradali ed aeroportuali - Metodi di prova - Parte 4: Metodo per la misurazione della resistenza allo slittamento/derapaggio di una superficie: Metodo del pendolo
+#### Massetti
+1. UNI EN 13318 Massetti e materiali per massetti – Definizioni.
+1. UNI EN 13813 Massetti e materiali per massetti – Materiali per massetti - Proprietà e requisiti.
+1. UNI EN 13892-1 Metodi di prova dei materiali per massetti - Parte 1: campionamento, confezionamento e maturazione dei provini.
+1. UNI EN 13892-2 Metodi di prova dei materiali per massetti - Parte 2: determinazione della Resistenza a flessione e a compressione.
+1. UNI 10827 Massetti. Rivestimenti in legno per pavimentazioni. Determinazione della resistenza meccanica alle sollecitazioni parallele al piano di posa
+1. UNI EN 13892-8 Metodi di prova dei materiali per massetti - Determinazione della forza di adesione
+1. UNI 10329 Posa dei rivestimenti di pavimentazione. Misurazione del contenuto di umidità negli strati di supporto cementizi o simili.
+1. UNI EN 196-1 Metodi di prova dei cementi - Parte 1: Determinazione delle resistenze meccaniche.
+1. Linee Guida Valutazione delle caratteristiche del CLS in opera
+#### Sistemi impiantistici pavimento
+1. UNI EN ISO 11855-5 Progettazione dell'ambiente costruito - Progettazione, dimensionamento,
+installazione e controllo dei sistemi di riscaldamento e raffreddamento radianti integrati - Parte 5: Installazione.
+1. UNI EN 1264-4 Istallazione – Parte 4: Sistemi radianti alimentati ad acqua per il riscaldamento e il raffrescamento integrati nelle strutture.

--- a/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
+++ b/D-Pavimentazioni e rivestimenti di pavimentazione/D-Refs.md
@@ -41,7 +41,8 @@
 1. Guida all'siolamento acustico e capitolati tecnici INDEX
 1. Rapporto di prova dell'siolamento acustico via aerea ISTITUTO GIORDANO (OD)
 1. Sistema per l'isolamento acustico contro il rumore di calpestio MAPEI
-
+#### Sistemi radianti
+1. pav radianti (OD), materiali compatibili con i sistemi radianti
 ### Riferimenti normativi
 #### Pavimentazioni in resina
 1. UNI 10966 Sistemi resinosi per superfici orizzontali, verticali e soffitti - Parte 1 : Istruzioni per la progettazione, la posa e la manutenzione


### PR DESCRIPTION
Ho organizzato il documento in : 
- Documenti produttori (divisi per tipologia)
- normativa (divisi per tipologia)
Integrando il materiale presente per il primo e aggiungendo per il secondo.
(OD) significa che il documento è presente in pdf (sarà poi da carincare su One Drive)
Ho iniziato concentrandomi sui rivestimenti